### PR TITLE
v1.0.0-beta45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
+## 1.0.0-beta44
+**Maintainer**: Raffael Sahli <sahli@gyselroth.com>\
+**Date**: Fr Sep 20 16:41:20 CEST 2019
+
+* CORE: [FIX] Error: Call to undefined method mysqli_stmt::fetch_assoc() in /usr/share/tubee/src/lib/Endpoint/Mysql.php:77
+
+
 ## 1.0.0-beta43
 **Maintainer**: Raffael Sahli <sahli@gyselroth.com>\
-**Date**: Wed Sep 20 15:47:20 CEST 2019
+**Date**: Fr Sep 20 15:47:20 CEST 2019
 
 * CORE: [FIX] ArgumentCountError: Wrong parameter count for mysqli_stmt::bind_param() in /usr/share/tubee/src/lib/Endpoint/Mysql/Wrapper.php:159
 * CORE: [FEATURE] Support query dsl for PdoEndpoint and MysqlEndpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.0-beta45
+**Maintainer**: Raffael Sahli <sahli@gyselroth.com>\
+**Date**: Wed Sep 25 12:21:20 CEST 2019
+
+* CORE: [FIX] Sort operation used more than the maximum 33554432 bytes of RAM. Add an index, or specify a smaller limit. There is now no sorting during stream requests.
+* CORE: [FIX] Errors during streams are now handled as StreamError and be returned to the requested as such.
+
+
 ## 1.0.0-beta44
 **Maintainer**: Raffael Sahli <sahli@gyselroth.com>\
 **Date**: Fr Sep 20 16:41:20 CEST 2019

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "php-jsonpatch/php-jsonpatch": "^3.0",
         "stolt/json-merge-patch": "^1.0",
         "psr/http-message": "^1.0",
-        "gyselroth/stream-iterator": "dev-master",
+        "gyselroth/stream-iterator": "^1.0.1",
         "guzzlehttp/guzzle": "~6.0",
         "paragonie/halite": "^4",
         "vanilla/garden-schema": "dev-master#0a93bb9",

--- a/src/lib/Endpoint/Mysql.php
+++ b/src/lib/Endpoint/Mysql.php
@@ -73,6 +73,7 @@ class Mysql extends AbstractSqlDatabase
         }
 
         $i = 0;
+        $result = $result->get_result();
 
         while ($row = $result->fetch_assoc()) {
             yield $this->build($row);
@@ -92,6 +93,7 @@ class Mysql extends AbstractSqlDatabase
 
         $sql = 'SELECT * FROM '.$this->table.' WHERE '.$filter;
         $result = $this->socket->prepareValues($sql, $values);
+        $result = $result->get_result();
 
         if ($result->num_rows > 1) {
             throw new Exception\ObjectMultipleFound('found more than one object with filter '.$filter);
@@ -100,7 +102,7 @@ class Mysql extends AbstractSqlDatabase
             throw new Exception\ObjectNotFound('no object found with filter '.$filter);
         }
 
-        return $this->build($result->fetch_assoc(), $query);
+        return $this->build($result->fetch(), $query);
     }
 
     /**

--- a/src/lib/Resource/Factory.php
+++ b/src/lib/Resource/Factory.php
@@ -249,10 +249,6 @@ class Factory
         ]);
 
         if ($existing === true) {
-            if (empty($sort)) {
-                $sort = ['created' => 1];
-            }
-
             $total = $collection->count($query);
 
             if ($offset !== null && $total === 0) {

--- a/src/lib/Rest/Helper.php
+++ b/src/lib/Rest/Helper.php
@@ -72,6 +72,7 @@ class Helper
 
         $query = $request->getQueryParams();
         $options = isset($query['pretty']) ? JSON_PRETTY_PRINT : 0;
+        $error = null;
 
         $stream = new StreamIterator($cursor, function ($resource) use ($request, $options) {
             if ($this->tell() === 0) {
@@ -85,6 +86,20 @@ class Helper
             if ($this->eof()) {
                 echo ']';
             }
+
+            flush();
+        }, function (\Throwable $e) {
+            if ($this->tell() === 0) {
+                echo  '[';
+            } else {
+                echo  ',';
+            }
+
+            echo json_encode([
+                'kind' => 'StreamError',
+                'error' => $e->getMessage(),
+                'class' => get_class($e),
+            ]).']';
 
             flush();
         });
@@ -121,6 +136,20 @@ class Helper
             if ($this->eof()) {
                 echo ']';
             }
+
+            flush();
+        }, function (\Throwable $e) {
+            if ($this->tell() === 0) {
+                echo  '[';
+            } else {
+                echo  ',';
+            }
+
+            echo json_encode(['ADDED', [
+                'kind' => 'StreamError',
+                'error' => $e->getMessage(),
+                'class' => get_class($e),
+            ]]).']';
 
             flush();
         });

--- a/src/lib/Rest/Middlewares/QueryDecoder.php
+++ b/src/lib/Rest/Middlewares/QueryDecoder.php
@@ -71,12 +71,6 @@ class QueryDecoder implements MiddlewareInterface
             $query['sort'] = [];
         }
 
-        if (isset($query['stream']) && empty($query['sort'])) {
-            $query['sort'] = ['created' => 1];
-        } elseif (empty($query['sort'])) {
-            $query['sort'] = ['created' => -1];
-        }
-
         $request = $request->withQueryParams($query);
 
         return $handler->handle($request);


### PR DESCRIPTION
* CORE: [FIX] Sort operation used more than the maximum 33554432 bytes of RAM. Add an index, or specify a smaller limit. There is now no sorting during stream requests.
* CORE: [FIX] Errors during streams are now handled as StreamError and be returned to the requested as such.
