### PR TITLE
feat(): CORS allow all headers

### DIFF
--- a/src/lib/Rest/Middlewares/CorsHandler.php
+++ b/src/lib/Rest/Middlewares/CorsHandler.php
@@ -44,8 +44,8 @@ class CorsHandler implements MiddlewareInterface
             return new UnformattedResponse(
                 (new Response())->withStatus(StatusCodeInterface::STATUS_NO_CONTENT)
                     ->withHeader('Access-Control-Allow-Origin', '*')
+                    ->withHeader('Access-Control-Allow-Headers', '*')
                     ->withHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS')
-                    ->withHeader('Access-Control-Allow-Headers', 'Authorization')
                     ->withHeader('Access-Control-Max-Age', '86400'),
                 []
             );


### PR DESCRIPTION
Since non-GET requests can send additional `Access-Control-Request-Headers` header items such as `content-type`:
Allow all headers instead of only `authorization`.